### PR TITLE
Add "Dubai" calculation method

### DIFF
--- a/prayer_times_calculator/pray_times_calculator.py
+++ b/prayer_times_calculator/pray_times_calculator.py
@@ -26,6 +26,7 @@ CALCULATION_METHODS: Final = {
     "turkey": 13,
     "russia": 14,
     "moonsighting": 15,
+    "dubai": 16,
     "custom": 99,
 }
 


### PR DESCRIPTION
I wanted to use Home Assistant's Prayer Times, which uses this module, but noticed "Dubai" wasn't listed, while it's supported by aladhan.com